### PR TITLE
Add resolution selection support to /rgen

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -9,6 +9,26 @@ comfyui:
         ssl_verify: false
       weight: 1
 
+resolutions:
+  - label: "Square — 1024x1024 (1:1)"
+    value: "square - 1024x1024 (1:1)"
+  - label: "Landscape — 1152x896 (4:5)"
+    value: "landscape - 1152x896 (4:5)"
+  - label: "Landscape — 1216x832 (3:2)"
+    value: "landscape - 1216x832 (3:2)"
+  - label: "Landscape — 1344x768 (16:9)"
+    value: "landscape - 1344x768 (16:9)"
+  - label: "Landscape — 1536x640 (21:9)"
+    value: "landscape - 1536x640 (21:9)"
+  - label: "Portrait — 896x1152 (4:5)"
+    value: "portrait - 896x1152 (4:5)"
+  - label: "Portrait — 832x1216 (2:3)"
+    value: "portrait - 832x1216 (2:3)"
+  - label: "Portrait — 768x1344 (9:16)"
+    value: "portrait - 768x1344 (9:16)"
+  - label: "Portrait — 640x1536 (2:3)"
+    value: "portrait - 640x1536 (2:3)"
+
 workflows:
   ExpNEW:
     type: txt2img
@@ -16,6 +36,8 @@ workflows:
     workflow: ./workflows/ExpNEW.json
     text_prompt_node_id: 45
     default: true
+    default_resolution: portrait - 832x1216 (2:3)
+    resolution_node_id: 9
     settings:
       - name: __before
         description: Will change steps for this workflow to the number provided in parenthesis
@@ -147,6 +169,8 @@ workflows:
     workflow: ./workflows/ExpNEWlandscape.json
     text_prompt_node_id: 45
     default: true
+    default_resolution: landscape - 1216x832 (3:2)
+    resolution_node_id: 9
     settings:
       - name: __before
         description: Will change steps for this workflow to the number provided in parenthesis

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -7,22 +7,40 @@ from discord import app_commands
 def rgen_command(bot):
     """Create the forge command for txt2img generation"""
 
+    resolution_choices = [
+        app_commands.Choice(name=label, value=value)
+        for label, value in bot.workflow_manager.get_resolution_presets()[:25]
+    ]
+
     @app_commands.command(
         name="rgen",
         description="Forge an image using text-to-image"
     )
     @app_commands.describe(
         prompt="Description of the image you want to create",
+        resolution="Select the output resolution (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
     )
     async def rgen(
             interaction: discord.Interaction,
             prompt: str,
+            resolution: Optional[app_commands.Choice[str]] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
-        await bot.handle_generation(interaction, 'txt2img', prompt, workflow, settings)
+        selected_resolution = resolution.value if resolution else None
+        await bot.handle_generation(
+            interaction,
+            'txt2img',
+            prompt,
+            workflow,
+            settings,
+            resolution=selected_resolution,
+        )
+
+    if resolution_choices:
+        rgen = app_commands.choices(resolution=resolution_choices)(rgen)
 
     return rgen
 
@@ -47,7 +65,14 @@ def reforge_command(bot):
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
-        await bot.handle_generation(interaction, 'img2img', prompt, workflow, settings, image)
+        await bot.handle_generation(
+            interaction,
+            'img2img',
+            prompt,
+            workflow,
+            settings,
+            input_image=image,
+        )
 
     return reforge
 
@@ -72,7 +97,14 @@ def upscale_command(bot):
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
-        await bot.handle_generation(interaction, 'upscale', prompt, workflow, settings, image)
+        await bot.handle_generation(
+            interaction,
+            'upscale',
+            prompt,
+            workflow,
+            settings,
+            input_image=image,
+        )
 
     return upscale
 


### PR DESCRIPTION
## Summary
- add configurable resolution presets and defaults for workflows
- expose resolution choices in the /rgen slash command and propagate the selection through generation handling
- apply the selected resolution when preparing workflows and show it in generation embeds

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd428bb0c48327856783d1f31fe260