### PR TITLE
Add spoiler tag controls and log usernames

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -9,6 +9,9 @@ comfyui:
         ssl_verify: false
       weight: 1
 
+spoilers:
+  tags: []
+
 resolutions:
   - label: "Square — 1024x1024 (1:1)"
     value: "square - 1024x1024 (1:1)"


### PR DESCRIPTION
## Summary
- add configuration support for spoiler tags and expose slash commands to list, add, and remove them
- mark generation updates as spoilers when prompts contain configured tags and record the configuration on disk
- include requester display names in generation logs alongside helper improvements for configuration loading

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915995b25b48333aaa67717451ed0b0)