### PR TITLE
Modernize role tiers with priority queueing

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -32,6 +32,8 @@ resolutions:
   - label: "Portrait — 640x1536 (9:21)"
     value: "portrait - 640x1536 (9:21)"
 
+prompt_presets_file: data/prompt_presets.json
+
 workflows:
   ExpNEW:
     type: txt2img

--- a/data/prompt_presets.json
+++ b/data/prompt_presets.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Desuka Main",
+    "tags": "(masterpiece, best quality, very aesthetic, absurdres, highers, high definition, amazing quality, ultra detailed, very awa:1.2), (kakure_eria:0.7), (PumpkinSpiceLatte:0.5), (blvefo9:0.5), (1=2),"
+  },
+  {
+    "name": "Desuka Main 2",
+    "tags": ["(masterpiece, best quality, very aesthetic, absurdres, highers, high definition, amazing quality, ultra detailed, very awa:1.2), (kakure_eria:0.7), (PumpkinSpiceLatte:0.5), (blvefo9:0.5), (1=2), butterchalk,"]
+  }
+]

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -183,20 +183,19 @@ def profile_command(bot):
         bot._reset_counts_if_needed()
         stats = bot.get_user_generation_summary(user_id)
 
-        supporter_role = await bot._has_unlimited_access(interaction)
+        tier = await bot._determine_user_tier(interaction)
         listed_donor = user_id in bot.donor_users
-        has_unlimited = supporter_role or listed_donor
+        has_unlimited = tier.daily_limit is None
 
-        status_details = []
-        if listed_donor:
-            status_details.append("listed as donor")
-        if supporter_role:
-            status_details.append("has supporter role")
+        status_details = [f"Tier: **{tier.name}**"]
+        if tier.queue_priority >= 30:
+            status_details.append("Priority queue access")
+        if tier.max_parallel_generations > 1:
+            status_details.append(f"Queue up to {tier.max_parallel_generations} at once")
+        if listed_donor and tier.level < bot.donor_tier.level:
+            status_details.append("Listed as donor")
 
-        if status_details:
-            sponsorship_status = f"💎 Active ({', '.join(status_details)})"
-        else:
-            sponsorship_status = "🪙 Inactive"
+        sponsorship_status = "\n".join(status_details)
 
         embed = discord.Embed(
             title="👤 User Profile",
@@ -217,11 +216,14 @@ def profile_command(bot):
         embed.add_field(name="💖 Sponsorship", value=sponsorship_status, inline=False)
 
         if has_unlimited:
-            limit_value = "Unlimited — thank you for supporting us!"
-            embed.add_field(name="💎 Daily limit", value=limit_value, inline=False)
+            limit_lines = ["Unlimited — thank you for supporting us!"]
+            limit_lines.append(f"Queue slots: **{tier.max_parallel_generations}**")
+            if tier.queue_priority >= 30:
+                limit_lines.append("Priority over lower tiers.")
+            embed.add_field(name="💎 Access", value="\n".join(limit_lines), inline=False)
         else:
             used = int(bot.user_generation_counts.get(user_id, 0))
-            limit = int(bot.DAILY_GENERATION_LIMIT)
+            limit = int(tier.daily_limit or 0)
             remaining = max(0, limit - used)
             reset_hint = bot._format_time_remaining()
             limit_lines = [

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -12,12 +12,22 @@ def rgen_command(bot):
         for label, value in bot.workflow_manager.get_resolution_presets()[:25]
     ]
 
+    async def _prompt_preset_autocomplete(
+            interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        presets = bot.workflow_manager.search_prompt_presets(current, limit=25)
+        return [
+            app_commands.Choice(name=preset.name, value=preset.value)
+            for preset in presets
+        ]
+
     @app_commands.command(
         name="rgen",
         description="Forge an image using text-to-image"
     )
     @app_commands.describe(
         prompt="Description of the image you want to create",
+        prompt_preset="Select a prompt preset (optional)",
         resolution="Select the output resolution (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
@@ -25,6 +35,7 @@ def rgen_command(bot):
     async def rgen(
             interaction: discord.Interaction,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             resolution: Optional[app_commands.Choice[str]] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
@@ -37,10 +48,12 @@ def rgen_command(bot):
             workflow,
             settings,
             resolution=selected_resolution,
+            prompt_preset=prompt_preset,
         )
 
     if resolution_choices:
         rgen = app_commands.choices(resolution=resolution_choices)(rgen)
+    rgen = app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(rgen)
 
     return rgen
 
@@ -55,6 +68,7 @@ def reforge_command(bot):
     @app_commands.describe(
         image="The image to reforge",
         prompt="Description of the changes you want to make",
+        prompt_preset="Select a prompt preset (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
     )
@@ -62,6 +76,7 @@ def reforge_command(bot):
             interaction: discord.Interaction,
             image: discord.Attachment,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
@@ -71,10 +86,11 @@ def reforge_command(bot):
             prompt,
             workflow,
             settings,
+            prompt_preset=prompt_preset,
             input_image=image,
         )
 
-    return reforge
+    return app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(reforge)
 
 
 def upscale_command(bot):
@@ -87,6 +103,7 @@ def upscale_command(bot):
     @app_commands.describe(
         image="The image to upscale",
         prompt="Description of the changes you want to make",
+        prompt_preset="Select a prompt preset (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
     )
@@ -94,6 +111,7 @@ def upscale_command(bot):
             interaction: discord.Interaction,
             image: discord.Attachment,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
@@ -103,10 +121,11 @@ def upscale_command(bot):
             prompt,
             workflow,
             settings,
+            prompt_preset=prompt_preset,
             input_image=image,
         )
 
-    return upscale
+    return app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(upscale)
 
 
 def workflows_command(bot):

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -1124,6 +1124,9 @@ class ComfyUIBot(commands.Bot):
         user_id = str(interaction.user.id)
         self._reset_counts_if_needed()
 
+        user_global_name = getattr(interaction.user, "global_name", None)
+        logger.info("gen[%s] global_name=%s", user_id, user_global_name or "—")
+
         if user_id in self.blocked_users:
             await self._send_blocked_message(interaction)
             return

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -679,12 +679,28 @@ class ComfyUIBot(commands.Bot):
 
             user_id = str(int(payload["user_id"]))
             used = int(payload["generations_used"])
-            limit = int(payload["limit"])
             reset_at = float(payload["reset_at"])
+            tier_info = payload.get("tier", {})
+            limit_raw = tier_info.get("limit", payload.get("limit"))
+            tier_name = tier_info.get("name", "unknown")
+            queue_priority = tier_info.get("queue_priority", 0)
+            max_parallel = tier_info.get("max_parallel", 1)
+            limit = None if limit_raw in (None, -1) else int(limit_raw)
             incoming_last_reset = reset_at - 86400.0
 
             if getattr(self, "last_reset_time", 0) > incoming_last_reset + 2:
                 logger.debug("SYNC skipped — local reset is newer")
+                return
+
+            if limit is None:
+                logger.debug(
+                    "SYNC ignored for unlimited tier • bot=%s user=%s tier=%s priority=%s max_parallel=%s",
+                    src_bot,
+                    user_id,
+                    tier_name,
+                    queue_priority,
+                    max_parallel,
+                )
                 return
 
             self.user_generation_counts[user_id] = used
@@ -692,11 +708,14 @@ class ComfyUIBot(commands.Bot):
             self._save_generation_counts()
 
             logger.info(
-                "SYNC applied from bot %s → user %s: %s/%s",
+                "SYNC applied from bot %s → user %s tier=%s: %s/%s (priority=%s max_parallel=%s)",
                 src_bot,
                 user_id,
+                tier_name,
                 used,
                 limit,
+                queue_priority,
+                max_parallel,
             )
 
         except Exception as exc:  # pragma: no cover - defensive
@@ -802,7 +821,17 @@ class ComfyUIBot(commands.Bot):
             if expiry <= now:
                 self._sync_seen.pop(key, None)
 
-    async def _publish_limit_update(self, user_id: int, used: int, limit: int, reset_at: float) -> None:
+    async def _publish_limit_update(
+        self,
+        *,
+        user_id: int,
+        used: int,
+        limit: Optional[int],
+        reset_at: float,
+        tier_name: str,
+        queue_priority: int,
+        max_parallel: int,
+    ) -> None:
         try:
             channel = self.get_channel(self.SYNC_CHANNEL_ID)
             if not channel:
@@ -820,8 +849,14 @@ class ComfyUIBot(commands.Bot):
                 "source_bot_id": self.user.id if self.user else 0,
                 "user_id": int(user_id),
                 "generations_used": int(used),
-                "limit": int(limit),
+                "limit": None if limit is None else int(limit),
                 "reset_at": float(reset_at),
+                "tier": {
+                    "name": tier_name,
+                    "limit": None if limit is None else int(limit),
+                    "queue_priority": int(queue_priority),
+                    "max_parallel": int(max_parallel),
+                },
             }
             wrapper = {"payload": payload, "sig": self._sync_sign(payload)}
             await channel.send(self.SYNC_PREFIX + self._sync_canon(wrapper))
@@ -1071,6 +1106,9 @@ class ComfyUIBot(commands.Bot):
                             used=int(self.user_generation_counts[user_id]),
                             limit=limit,
                             reset_at=float(self.last_reset_time + 86400.0),
+                            tier_name=tier.name,
+                            queue_priority=tier.queue_priority,
+                            max_parallel=tier.max_parallel_generations,
                         )
                     )
                 except Exception as exc:  # pragma: no cover - defensive
@@ -1476,6 +1514,9 @@ class ComfyUIBot(commands.Bot):
                         used=new_value,
                         limit=context.daily_limit or self._get_public_tier().daily_limit or 0,
                         reset_at=float(self.last_reset_time + 86400.0),
+                        tier_name=context.tier.name,
+                        queue_priority=context.tier.queue_priority,
+                        max_parallel=context.tier.max_parallel_generations,
                     )
                 )
             except Exception as exc:  # pragma: no cover - defensive

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -103,6 +103,7 @@ class ComfyUIBot(commands.Bot):
         # Generation tracking
         self.active_generations: Dict[str, List[GenerationContext]] = defaultdict(list)
         self.synced_active_slots: Dict[str, int] = defaultdict(int)
+        self._sync_channel_cache: Optional[discord.abc.Messageable] = None
 
         # Spoiler handling
         self._spoiler_tags: Set[str] = set()
@@ -848,6 +849,22 @@ class ComfyUIBot(commands.Bot):
             if expiry <= now:
                 self._sync_seen.pop(key, None)
 
+    async def _get_sync_channel(self) -> Optional[discord.abc.Messageable]:
+        if self._sync_channel_cache:
+            return self._sync_channel_cache
+
+        channel = self.get_channel(self.SYNC_CHANNEL_ID)
+        if not channel:
+            try:
+                channel = await self.fetch_channel(self.SYNC_CHANNEL_ID)
+            except Exception:
+                channel = None
+
+        if channel:
+            self._sync_channel_cache = channel
+
+        return channel
+
     async def _publish_limit_update(
         self,
         *,
@@ -903,13 +920,8 @@ class ComfyUIBot(commands.Bot):
         max_parallel: int,
     ) -> None:
         try:
-            channel = self.get_channel(self.SYNC_CHANNEL_ID)
-            if not channel:
-                try:
-                    channel = await self.fetch_channel(self.SYNC_CHANNEL_ID)
-                except Exception:
-                    channel = None
-            if not channel:
+            channel = await self._get_sync_channel()
+            if not channel or not self.SYNC_CHANNEL_ID:
                 return
 
             event_id = str(uuid.uuid4())

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -34,6 +34,19 @@ from ..ui.views import GenerationView
 
 
 @dataclass
+@dataclass(frozen=True)
+class RoleTier:
+    """Represents an access tier driven by Discord roles."""
+
+    level: int
+    name: str
+    role_id: Optional[int]
+    daily_limit: Optional[int]
+    queue_priority: int
+    max_parallel_generations: int
+
+
+@dataclass
 class GenerationContext:
     """State for a single in-flight generation."""
 
@@ -50,6 +63,8 @@ class GenerationContext:
     prompt_id: Optional[str] = None
     cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
     view: Optional[GenerationView] = None
+    tier: RoleTier = field(default_factory=lambda: RoleTier(0, "Public", None, 25, 0, 1))
+    daily_limit: Optional[int] = None
     counted_usage: bool = False
     completed: bool = False
     cancelled_notified: bool = False
@@ -59,7 +74,6 @@ class GenerationContext:
 
 class ComfyUIBot(commands.Bot):
     GENERATION_COUNTS_FILE = "generation_counts.yml"
-    DAILY_GENERATION_LIMIT = 50
     QUEUE_STUCK_THRESHOLD = 1800  # 30 minutes
     STATS_RETENTION_DAYS = 90
 
@@ -86,7 +100,7 @@ class ComfyUIBot(commands.Bot):
         self.plugins: List[Plugin] = []
 
         # Generation tracking
-        self.active_generations: Dict[str, GenerationContext] = {}
+        self.active_generations: Dict[str, List[GenerationContext]] = defaultdict(list)
 
         # Spoiler handling
         self._spoiler_tags: Set[str] = set()
@@ -105,6 +119,56 @@ class ComfyUIBot(commands.Bot):
         self.access_guild_id: Optional[str] = None
         self.supporter_role_name: str = "Supporter"
         self.supporter_role_id: Optional[str] = None
+        self.role_tiers: List[RoleTier] = [
+            RoleTier(
+                level=4,
+                name="Level 4",
+                role_id=1451769149045997588,
+                daily_limit=None,
+                queue_priority=40,
+                max_parallel_generations=30,
+            ),
+            RoleTier(
+                level=3,
+                name="Level 3",
+                role_id=1451768900453925030,
+                daily_limit=None,
+                queue_priority=30,
+                max_parallel_generations=3,
+            ),
+            RoleTier(
+                level=2,
+                name="Level 2",
+                role_id=1361296590777745560,
+                daily_limit=None,
+                queue_priority=0,
+                max_parallel_generations=1,
+            ),
+            RoleTier(
+                level=1,
+                name="Level 1",
+                role_id=1450781064418299914,
+                daily_limit=100,
+                queue_priority=0,
+                max_parallel_generations=1,
+            ),
+            RoleTier(
+                level=0,
+                name="Public",
+                role_id=None,
+                daily_limit=25,
+                queue_priority=0,
+                max_parallel_generations=1,
+            ),
+        ]
+        self.donor_tier = RoleTier(
+            level=2,
+            name="Donor",
+            role_id=None,
+            daily_limit=None,
+            queue_priority=0,
+            max_parallel_generations=1,
+        )
         self.user_generation_counts: Dict[str, int] = defaultdict(int)
         self.user_generation_stats: Dict[str, Dict[str, Any]] = {}
         self.last_reset_time: float = time.time()
@@ -186,20 +250,11 @@ class ComfyUIBot(commands.Bot):
             self._set_spoiler_tags(config_data.get("spoilers", {}).get("tags", []))
 
             logger.info(
-                "Security configuration loaded • blocked=%d donors=%d",
+                "Security configuration loaded • blocked=%d donors=%d access_guild=%s",
                 len(self.blocked_users),
                 len(self.donor_users),
+                self.access_guild_id or "disabled",
             )
-
-            if self.access_guild_id:
-                role_descriptor = self.supporter_role_id or self.supporter_role_name
-                logger.info(
-                    "Supporter role checks enabled • guild=%s role=%s",
-                    self.access_guild_id,
-                    role_descriptor,
-                )
-            else:
-                logger.warning("Supporter role checks disabled: access_guild_id is not configured")
 
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Failed to load security configuration: %s", exc)
@@ -271,6 +326,10 @@ class ComfyUIBot(commands.Bot):
             or str(user)
         )
         return f"{base_name} ({getattr(user, 'id', '?')})"
+
+    def _get_active_contexts(self, user_id: str) -> List[GenerationContext]:
+        contexts = self.active_generations.get(user_id, [])
+        return [ctx for ctx in contexts if not ctx.finalized]
 
     async def _ensure_manage_guild(self, interaction: discord.Interaction) -> bool:
         perms = getattr(interaction.user, "guild_permissions", None)
@@ -437,6 +496,76 @@ class ComfyUIBot(commands.Bot):
         minutes = int((remaining % 3600) // 60)
         return f"{hours}h {minutes}m"
 
+    def _get_public_tier(self) -> RoleTier:
+        for tier in self.role_tiers:
+            if tier.level == 0:
+                return tier
+        return RoleTier(0, "Public", None, 25, 0, 1)
+
+    async def _get_access_guild(self) -> Optional[discord.Guild]:
+        if not self.access_guild_id:
+            logger.debug("access-guild: skip (id empty)")
+            return None
+
+        try:
+            gid = int(self.access_guild_id)
+        except Exception:
+            logger.warning("access-guild: invalid id=%r", self.access_guild_id)
+            return None
+
+        guild = self.get_guild(gid)
+        if guild:
+            return guild
+
+        try:
+            guild = await self.fetch_guild(gid)
+            logger.debug("access-guild: fetched guild %s", gid)
+            return guild
+        except Exception as exc:
+            logger.warning("access-guild: fetch_guild(%s) failed: %s", gid, exc)
+            return None
+
+    async def _get_access_member(self, interaction: discord.Interaction) -> Optional[discord.Member]:
+        try:
+            guild = await self._get_access_guild()
+            if not guild:
+                return None
+
+            if interaction.guild and interaction.guild.id == guild.id:
+                target_guild = interaction.guild
+                logger.debug("access-member: using interaction guild %s", guild.id)
+            else:
+                target_guild = guild
+
+            member = target_guild.get_member(interaction.user.id)
+            if member:
+                return member
+
+            try:
+                member = await target_guild.fetch_member(interaction.user.id)
+                logger.debug("access-member: fetched member %s on guild %s", interaction.user.id, target_guild.id)
+                return member
+            except Exception as exc:
+                logger.info("access-member: user %s not in guild %s (%s)", interaction.user.id, target_guild.id, exc)
+                return None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("access-member: failed %s", exc)
+            return None
+
+    async def _determine_user_tier(self, interaction: discord.Interaction) -> RoleTier:
+        highest = self._get_public_tier()
+        member = await self._get_access_member(interaction)
+        role_ids: Set[int] = {r.id for r in getattr(member, "roles", [])} if member else set()
+
+        for tier in self.role_tiers:
+            if tier.role_id and tier.role_id in role_ids and tier.level > highest.level:
+                highest = tier
+
+        if str(interaction.user.id) in self.donor_users and highest.level < self.donor_tier.level:
+            highest = self.donor_tier
+
+        return highest
+
     # ------------------------------------------------------------------
     # Background monitoring
     # ------------------------------------------------------------------
@@ -447,7 +576,8 @@ class ComfyUIBot(commands.Bot):
         current_time = time.time()
         stuck_contexts = [
             context
-            for context in list(self.active_generations.values())
+            for contexts in list(self.active_generations.values())
+            for context in contexts
             if current_time - context.started_at > self.QUEUE_STUCK_THRESHOLD
         ]
 
@@ -709,12 +839,17 @@ class ComfyUIBot(commands.Bot):
             user_id = str(interaction.user.id)
             self._reset_counts_if_needed()
 
-            is_donor = user_id in self.donor_users or await self._has_unlimited_access(interaction)
+            tier = await self._determine_user_tier(interaction)
+            is_donor = tier.daily_limit is None
             count = self.user_generation_counts.get(user_id, 0)
+            queue_info = f"Queue slots: **{tier.max_parallel_generations}** at once."
+            priority_hint = "Priority over lower tiers." if tier.queue_priority >= 30 else "Standard queue priority."
 
             if is_donor:
                 description = (
-                    "🌟 **Donor status**: unlimited access!\n"
+                    f"🌟 **{tier.name}**: unlimited access!\n"
+                    f"{queue_info}\n"
+                    f"{priority_hint}\n"
                     "Thank you for supporting the project."
                 )
                 embed = ui_embeds.build_notice_embed(
@@ -725,11 +860,13 @@ class ComfyUIBot(commands.Bot):
             else:
                 usage = ui_embeds.format_usage_bar(
                     count,
-                    self.DAILY_GENERATION_LIMIT,
+                    tier.daily_limit or 0,
                     reset_hint=f"resets in {self._format_time_remaining()}",
                 )
                 description = (
-                    "🔒 You are using the public tier.\n"
+                    f"🔒 You are using the {tier.name} tier.\n"
+                    f"{queue_info}\n"
+                    f"{priority_hint}\n"
                     "Support us to unlock unlimited generations!"
                 )
                 embed = ui_embeds.build_notice_embed(
@@ -879,8 +1016,14 @@ class ComfyUIBot(commands.Bot):
             await self._send_access_guild_required_message(interaction)
             return
 
-        if user_id in self.active_generations and not self.active_generations[user_id].finalized:
-            await self._send_active_generation_message(interaction)
+        tier = await self._determine_user_tier(interaction)
+        active_contexts = self._get_active_contexts(user_id)
+        if len(active_contexts) >= tier.max_parallel_generations:
+            await self._send_active_generation_message(
+                interaction,
+                max_allowed=tier.max_parallel_generations,
+                active_count=len(active_contexts),
+            )
             return
 
         logger.info(
@@ -892,7 +1035,7 @@ class ComfyUIBot(commands.Bot):
             resolution or "default",
         )
 
-        is_supporter = await self._has_unlimited_access(interaction)
+        is_supporter = tier.daily_limit is None
         is_donor = is_supporter or user_id in self.donor_users
 
         context = GenerationContext(
@@ -900,6 +1043,8 @@ class ComfyUIBot(commands.Bot):
             user=interaction.user,
             workflow_type=workflow_type,
             is_donor=is_donor,
+            tier=tier,
+            daily_limit=tier.daily_limit,
             prompt=prompt,
             settings=settings,
             resolution=resolution,
@@ -908,10 +1053,11 @@ class ComfyUIBot(commands.Bot):
         context.force_spoiler = self._prompt_contains_spoiler_tag(prompt)
 
         try:
-            if not is_donor:
+            if tier.daily_limit is not None:
                 current_usage = self.user_generation_counts[user_id]
-                if current_usage >= self.DAILY_GENERATION_LIMIT:
-                    await self._send_limit_reached_message(interaction)
+                limit = tier.daily_limit
+                if current_usage >= limit:
+                    await self._send_limit_reached_message(interaction, limit, tier.name)
                     return
 
                 self.user_generation_counts[user_id] = current_usage + 1
@@ -923,14 +1069,14 @@ class ComfyUIBot(commands.Bot):
                         self._publish_limit_update(
                             user_id=int(user_id),
                             used=int(self.user_generation_counts[user_id]),
-                            limit=self.DAILY_GENERATION_LIMIT,
+                            limit=limit,
                             reset_at=float(self.last_reset_time + 86400.0),
                         )
                     )
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.debug("SYNC publish skipped: %s", exc)
 
-            self.active_generations[user_id] = context
+            self.active_generations[user_id].append(context)
             await self._process_generation(
                 interaction,
                 workflow_type,
@@ -1052,6 +1198,7 @@ class ComfyUIBot(commands.Bot):
             settings,
             context.resolution,
             image_data,
+            priority=context.tier.queue_priority,
         )
     async def _run_generation_pipeline(
         self,
@@ -1249,9 +1396,11 @@ class ComfyUIBot(commands.Bot):
             return "💎 Unlimited access"
 
         used = self.user_generation_counts.get(context.user_id, 0)
+        if context.daily_limit is None:
+            return None
         return ui_embeds.format_usage_bar(
             used,
-            self.DAILY_GENERATION_LIMIT,
+            context.daily_limit,
             reset_hint=f"resets in {self._format_time_remaining()}",
         )
 
@@ -1301,7 +1450,16 @@ class ComfyUIBot(commands.Bot):
             return
 
         context.finalized = True
-        self.active_generations.pop(context.user_id, None)
+        active = self.active_generations.get(context.user_id, [])
+        if active:
+            try:
+                active.remove(context)
+            except ValueError:
+                pass
+            if active:
+                self.active_generations[context.user_id] = active
+            else:
+                self.active_generations.pop(context.user_id, None)
 
         if success:
             self._record_successful_generation(context.user_id)
@@ -1316,7 +1474,7 @@ class ComfyUIBot(commands.Bot):
                     self._publish_limit_update(
                         user_id=int(context.user_id),
                         used=new_value,
-                        limit=self.DAILY_GENERATION_LIMIT,
+                        limit=context.daily_limit or self._get_public_tier().daily_limit or 0,
                         reset_at=float(self.last_reset_time + 86400.0),
                     )
                 )
@@ -1331,23 +1489,32 @@ class ComfyUIBot(commands.Bot):
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
-    async def _send_active_generation_message(self, interaction: discord.Interaction) -> None:
+    async def _send_active_generation_message(
+        self,
+        interaction: discord.Interaction,
+        *,
+        max_allowed: int,
+        active_count: int,
+    ) -> None:
         embed = ui_embeds.build_notice_embed(
             title="⏳ Already processing",
-            description="Please wait for your current generation to finish before starting a new one.",
+            description=(
+                "Please wait for your existing generations to finish before starting a new one.\n"
+                f"Slots used: **{active_count}** / **{max_allowed}**"
+            ),
             color=ui_embeds.WARNING_COLOR,
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
-    async def _send_limit_reached_message(self, interaction: discord.Interaction) -> None:
+    async def _send_limit_reached_message(self, interaction: discord.Interaction, limit: int, tier_name: str) -> None:
         usage = ui_embeds.format_usage_bar(
             self.user_generation_counts[str(interaction.user.id)],
-            self.DAILY_GENERATION_LIMIT,
+            limit,
             reset_hint=f"resets in {self._format_time_remaining()}",
         )
         embed = ui_embeds.build_limit_embed(
             description=(
-                "You've reached the daily limit for the public tier.\n"
+                f"You've reached the daily limit for the {tier_name} tier.\n"
                 "Support us to unlock unlimited generations!\n\n"
                 f"{usage}"
             )
@@ -1368,36 +1535,8 @@ class ComfyUIBot(commands.Bot):
                 logger.debug("access-guild: skip (id empty)")
                 return True
 
-            try:
-                gid = int(self.access_guild_id)
-            except Exception:
-                logger.warning("access-guild: invalid id=%r", self.access_guild_id)
-                return False
-
-            if interaction.guild and interaction.guild.id == gid:
-                target_guild = interaction.guild
-                logger.debug("access-guild: using interaction guild %s", gid)
-            else:
-                target_guild = self.get_guild(gid)
-                if target_guild is None:
-                    try:
-                        target_guild = await self.fetch_guild(gid)
-                        logger.debug("access-guild: fetched guild %s", gid)
-                    except Exception as exc:
-                        logger.warning("access-guild: fetch_guild(%s) failed: %s", gid, exc)
-                        return False
-
-            member = target_guild.get_member(interaction.user.id)
-            if member is not None:
-                return True
-
-            try:
-                await target_guild.fetch_member(interaction.user.id)
-                logger.debug("access-guild: fetched member %s on guild %s", interaction.user.id, gid)
-                return True
-            except Exception as exc:
-                logger.info("access-guild: user %s not in guild %s (%s)", interaction.user.id, gid, exc)
-                return False
+            member = await self._get_access_member(interaction)
+            return member is not None
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("access-guild: failed %s", exc)
             return False
@@ -1411,78 +1550,5 @@ class ComfyUIBot(commands.Bot):
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     async def _has_unlimited_access(self, interaction: discord.Interaction) -> bool:
-        try:
-            if not self.access_guild_id:
-                logger.debug("supporter: skip (id empty)")
-                return False
-
-            try:
-                gid = int(self.access_guild_id)
-            except Exception:
-                logger.warning("supporter: invalid id=%r", self.access_guild_id)
-                return False
-
-            if interaction.guild and interaction.guild.id == gid:
-                target_guild = interaction.guild
-                logger.debug("supporter: using interaction guild %s", gid)
-            else:
-                target_guild = self.get_guild(gid)
-                if target_guild is None:
-                    try:
-                        target_guild = await self.fetch_guild(gid)
-                        logger.debug("supporter: fetched guild %s", gid)
-                    except Exception as exc:
-                        logger.warning("supporter: fetch_guild(%s) failed: %s", gid, exc)
-                        return False
-
-            member = target_guild.get_member(interaction.user.id)
-            if member is None:
-                try:
-                    member = await target_guild.fetch_member(interaction.user.id)
-                    logger.debug("supporter: fetched member %s on guild %s", interaction.user.id, gid)
-                except Exception as exc:
-                    logger.info("supporter: user %s not in guild %s (%s)", interaction.user.id, gid, exc)
-                    return False
-
-            role = None
-            if getattr(self, "supporter_role_id", None):
-                try:
-                    rid = int(self.supporter_role_id)
-                    role = target_guild.get_role(rid)
-                    if role:
-                        logger.debug("Supporter check: found role by ID %s: %s", rid, role.name)
-                except Exception:
-                    role = None
-
-            if role is None and getattr(self, "supporter_role_name", None):
-                lname = self.supporter_role_name.casefold()
-                for candidate in target_guild.roles:
-                    if candidate.name.casefold() == lname:
-                        role = candidate
-                        logger.debug("Supporter check: found role by name %s -> %s", self.supporter_role_name, candidate.id)
-                        break
-
-            if not role:
-                logger.warning(
-                    "Supporter check: role not found on guild (guild_id=%s, role_id=%s, role_name=%r)",
-                    gid,
-                    getattr(self, "supporter_role_id", None),
-                    getattr(self, "supporter_role_name", None),
-                )
-                return False
-
-            member_role_ids = {r.id for r in getattr(member, "roles", [])}
-            has_role = role.id in member_role_ids
-            logger.info(
-                "Supporter check: guild=%s member=%s role=%s/%s has=%s",
-                gid,
-                member.id,
-                role.id,
-                role.name,
-                has_role,
-            )
-            return has_role
-
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Supporter role check failed: %s", exc, exc_info=True)
-            return False
+        tier = await self._determine_user_tier(interaction)
+        return tier.daily_limit is None

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -1520,11 +1520,7 @@ class ComfyUIBot(commands.Bot):
         if extra_fields:
             fields.extend(extra_fields)
         if context.prompt_preset_name:
-            preset_value = context.prompt_preset_name
-            if context.prompt_preset_tags:
-                tags_preview = self._truncate_field(context.prompt_preset_tags, 900)
-                preset_value = f"{context.prompt_preset_name}\n{tags_preview}"
-            fields.append(("🏷️ Preset", preset_value, False))
+            fields.append(("🏷️ Preset", context.prompt_preset_name, True))
         if context.resolution:
             fields.append(("🖼️ Resolution", context.resolution, True))
         fields.append(("🕒 Started", f"<t:{int(context.started_at)}:R>", True))
@@ -1540,11 +1536,6 @@ class ComfyUIBot(commands.Bot):
             usage=self._usage_text(context),
             fields=fields,
         )
-
-    def _truncate_field(self, value: str, limit: int = 900) -> str:
-        if len(value) <= limit:
-            return value
-        return value[: limit - 1] + "…"
 
     def _usage_text(self, context: GenerationContext) -> Optional[str]:
         if context.is_donor:

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -55,6 +55,8 @@ class GenerationContext:
     workflow_type: str
     is_donor: bool
     prompt: Optional[str] = None
+    prompt_preset_name: Optional[str] = None
+    prompt_preset_tags: Optional[str] = None
     settings: Optional[str] = None
     resolution: Optional[str] = None
     started_at: float = field(default_factory=time.time)
@@ -1119,7 +1121,9 @@ class ComfyUIBot(commands.Bot):
         workflow: Optional[str] = None,
         settings: Optional[str] = None,
         resolution: Optional[str] = None,
+        prompt_preset: Optional[str] = None,
         input_image: Optional[discord.Attachment] = None,
+        **_: Any,
     ) -> None:
         user_id = str(interaction.user.id)
         self._reset_counts_if_needed()
@@ -1158,6 +1162,8 @@ class ComfyUIBot(commands.Bot):
         is_supporter = tier.daily_limit is None
         is_donor = is_supporter or user_id in self.donor_users
 
+        final_prompt, preset_name, preset_tags = self.workflow_manager.apply_prompt_preset(prompt_preset, prompt)
+
         context = GenerationContext(
             user_id=user_id,
             user=interaction.user,
@@ -1165,12 +1171,14 @@ class ComfyUIBot(commands.Bot):
             is_donor=is_donor,
             tier=tier,
             daily_limit=tier.daily_limit,
-            prompt=prompt,
+            prompt=final_prompt,
+            prompt_preset_name=preset_name,
+            prompt_preset_tags=preset_tags,
             settings=settings,
             resolution=resolution,
         )
 
-        context.force_spoiler = self._prompt_contains_spoiler_tag(prompt)
+        context.force_spoiler = self._prompt_contains_spoiler_tag(final_prompt)
 
         try:
             if tier.daily_limit is not None:
@@ -1203,9 +1211,9 @@ class ComfyUIBot(commands.Bot):
             context.slot_counted = True
             try:
                 asyncio.create_task(
-                    self._publish_active_delta(
-                        user_id=int(user_id),
-                        delta=1,
+                self._publish_active_delta(
+                    user_id=int(user_id),
+                    delta=1,
                         tier_name=tier.name,
                         queue_priority=tier.queue_priority,
                         max_parallel=tier.max_parallel_generations,
@@ -1216,7 +1224,7 @@ class ComfyUIBot(commands.Bot):
             await self._process_generation(
                 interaction,
                 workflow_type,
-                prompt,
+                final_prompt,
                 workflow,
                 settings,
                 resolution,
@@ -1511,6 +1519,12 @@ class ComfyUIBot(commands.Bot):
         fields: List[ui_embeds.EmbedField] = [("🎯 Mode", context.workflow_type.upper(), True)]
         if extra_fields:
             fields.extend(extra_fields)
+        if context.prompt_preset_name:
+            preset_value = context.prompt_preset_name
+            if context.prompt_preset_tags:
+                tags_preview = self._truncate_field(context.prompt_preset_tags, 900)
+                preset_value = f"{context.prompt_preset_name}\n{tags_preview}"
+            fields.append(("🏷️ Preset", preset_value, False))
         if context.resolution:
             fields.append(("🖼️ Resolution", context.resolution, True))
         fields.append(("🕒 Started", f"<t:{int(context.started_at)}:R>", True))
@@ -1526,6 +1540,11 @@ class ComfyUIBot(commands.Bot):
             usage=self._usage_text(context),
             fields=fields,
         )
+
+    def _truncate_field(self, value: str, limit: int = 900) -> str:
+        if len(value) <= limit:
+            return value
+        return value[: limit - 1] + "…"
 
     def _usage_text(self, context: GenerationContext) -> Optional[str]:
         if context.is_donor:

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -66,6 +66,7 @@ class GenerationContext:
     tier: RoleTier = field(default_factory=lambda: RoleTier(0, "Public", None, 25, 0, 1))
     daily_limit: Optional[int] = None
     counted_usage: bool = False
+    slot_counted: bool = False
     completed: bool = False
     cancelled_notified: bool = False
     finalized: bool = False
@@ -101,6 +102,7 @@ class ComfyUIBot(commands.Bot):
 
         # Generation tracking
         self.active_generations: Dict[str, List[GenerationContext]] = defaultdict(list)
+        self.synced_active_slots: Dict[str, int] = defaultdict(int)
 
         # Spoiler handling
         self._spoiler_tags: Set[str] = set()
@@ -330,6 +332,9 @@ class ComfyUIBot(commands.Bot):
     def _get_active_contexts(self, user_id: str) -> List[GenerationContext]:
         contexts = self.active_generations.get(user_id, [])
         return [ctx for ctx in contexts if not ctx.finalized]
+
+    def _get_remote_active_slots(self, user_id: str) -> int:
+        return max(0, int(self.synced_active_slots.get(user_id, 0)))
 
     async def _ensure_manage_guild(self, interaction: discord.Interaction) -> bool:
         perms = getattr(interaction.user, "guild_permissions", None)
@@ -668,6 +673,7 @@ class ComfyUIBot(commands.Bot):
             payload = data["payload"]
             event_id = payload["event_id"]
             src_bot = int(payload["source_bot_id"])
+            kind = payload.get("kind", "limit")
 
             self._sync_prune_seen()
             if event_id in self._sync_seen:
@@ -678,13 +684,34 @@ class ComfyUIBot(commands.Bot):
                 return
 
             user_id = str(int(payload["user_id"]))
-            used = int(payload["generations_used"])
-            reset_at = float(payload["reset_at"])
             tier_info = payload.get("tier", {})
-            limit_raw = tier_info.get("limit", payload.get("limit"))
             tier_name = tier_info.get("name", "unknown")
             queue_priority = tier_info.get("queue_priority", 0)
             max_parallel = tier_info.get("max_parallel", 1)
+
+            if kind == "active_delta":
+                delta = int(payload.get("delta", 0))
+                current = self._get_remote_active_slots(user_id)
+                updated = max(0, current + delta)
+                if updated:
+                    self.synced_active_slots[user_id] = updated
+                else:
+                    self.synced_active_slots.pop(user_id, None)
+
+                logger.info(
+                    "SYNC active slots update from bot %s → user %s tier=%s delta=%s total_remote=%s (max_parallel=%s)",
+                    src_bot,
+                    user_id,
+                    tier_name,
+                    delta,
+                    updated,
+                    max_parallel,
+                )
+                return
+
+            used = int(payload["generations_used"])
+            reset_at = float(payload["reset_at"])
+            limit_raw = tier_info.get("limit", payload.get("limit"))
             limit = None if limit_raw in (None, -1) else int(limit_raw)
             incoming_last_reset = reset_at - 86400.0
 
@@ -831,7 +858,7 @@ class ComfyUIBot(commands.Bot):
         tier_name: str,
         queue_priority: int,
         max_parallel: int,
-    ) -> None:
+        ) -> None:
         try:
             channel = self.get_channel(self.SYNC_CHANNEL_ID)
             if not channel:
@@ -844,6 +871,7 @@ class ComfyUIBot(commands.Bot):
 
             event_id = str(uuid.uuid4())
             payload = {
+                "kind": "limit",
                 "event_id": event_id,
                 "ts": int(self._sync_now()),
                 "source_bot_id": self.user.id if self.user else 0,
@@ -864,6 +892,47 @@ class ComfyUIBot(commands.Bot):
             self._sync_prune_seen()
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("publish_limit_update failed: %s", exc, exc_info=True)
+
+    async def _publish_active_delta(
+        self,
+        *,
+        user_id: int,
+        delta: int,
+        tier_name: str,
+        queue_priority: int,
+        max_parallel: int,
+    ) -> None:
+        try:
+            channel = self.get_channel(self.SYNC_CHANNEL_ID)
+            if not channel:
+                try:
+                    channel = await self.fetch_channel(self.SYNC_CHANNEL_ID)
+                except Exception:
+                    channel = None
+            if not channel:
+                return
+
+            event_id = str(uuid.uuid4())
+            payload = {
+                "kind": "active_delta",
+                "event_id": event_id,
+                "ts": int(self._sync_now()),
+                "source_bot_id": self.user.id if self.user else 0,
+                "user_id": int(user_id),
+                "delta": int(delta),
+                "tier": {
+                    "name": tier_name,
+                    "limit": None,
+                    "queue_priority": int(queue_priority),
+                    "max_parallel": int(max_parallel),
+                },
+            }
+            wrapper = {"payload": payload, "sig": self._sync_sign(payload)}
+            await channel.send(self.SYNC_PREFIX + self._sync_canon(wrapper))
+            self._sync_seen[event_id] = self._sync_now() + self._sync_seen_ttl
+            self._sync_prune_seen()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("publish_active_delta failed: %s", exc, exc_info=True)
 
     # ------------------------------------------------------------------
     # Commands
@@ -1053,11 +1122,12 @@ class ComfyUIBot(commands.Bot):
 
         tier = await self._determine_user_tier(interaction)
         active_contexts = self._get_active_contexts(user_id)
-        if len(active_contexts) >= tier.max_parallel_generations:
+        global_active = len(active_contexts) + self._get_remote_active_slots(user_id)
+        if global_active >= tier.max_parallel_generations:
             await self._send_active_generation_message(
                 interaction,
                 max_allowed=tier.max_parallel_generations,
-                active_count=len(active_contexts),
+                active_count=global_active,
             )
             return
 
@@ -1115,6 +1185,19 @@ class ComfyUIBot(commands.Bot):
                     logger.debug("SYNC publish skipped: %s", exc)
 
             self.active_generations[user_id].append(context)
+            context.slot_counted = True
+            try:
+                asyncio.create_task(
+                    self._publish_active_delta(
+                        user_id=int(user_id),
+                        delta=1,
+                        tier_name=tier.name,
+                        queue_priority=tier.queue_priority,
+                        max_parallel=tier.max_parallel_generations,
+                    )
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("SYNC active publish skipped: %s", exc)
             await self._process_generation(
                 interaction,
                 workflow_type,
@@ -1522,6 +1605,20 @@ class ComfyUIBot(commands.Bot):
             except Exception as exc:  # pragma: no cover - defensive
                 logger.debug("SYNC publish rollback skipped: %s", exc)
 
+        if context.slot_counted:
+            try:
+                asyncio.create_task(
+                    self._publish_active_delta(
+                        user_id=int(context.user_id),
+                        delta=-1,
+                        tier_name=context.tier.name,
+                        queue_priority=context.tier.queue_priority,
+                        max_parallel=context.tier.max_parallel_generations,
+                    )
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("SYNC active rollback skipped: %s", exc)
+
     async def _send_blocked_message(self, interaction: discord.Interaction) -> None:
         embed = ui_embeds.build_notice_embed(
             title="🚫 Access restricted",
@@ -1541,7 +1638,7 @@ class ComfyUIBot(commands.Bot):
             title="⏳ Already processing",
             description=(
                 "Please wait for your existing generations to finish before starting a new one.\n"
-                f"Slots used: **{active_count}** / **{max_allowed}**"
+                f"Slots in use across all bots: **{active_count}** / **{max_allowed}**"
             ),
             color=ui_embeds.WARNING_COLOR,
         )

--- a/src/comfy/workflow_manager.py
+++ b/src/comfy/workflow_manager.py
@@ -1,5 +1,7 @@
 import json
+import re
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -8,15 +10,46 @@ import yaml
 from logger import logger
 
 
+@dataclass(frozen=True)
+class PromptPreset:
+    name: str
+    tags: str
+    value: str
+
+    def apply(self, prompt: Optional[str]) -> str:
+        """Prepend the preset tags to the provided prompt."""
+
+        base_prompt = prompt.strip() if prompt else ""
+        prefix = self.tags.strip()
+
+        if not prefix:
+            return base_prompt
+
+        return f"{prefix} {base_prompt}".strip()
+
+
 class WorkflowManager:
     """Manages ComfyUI workflows and their configurations"""
     def __init__(self, config_path: str):
+        self.config_path = Path(config_path)
         self.config = self._load_config(config_path)
         self.workflows = self.config['workflows']
         self.default_workflow = self.config.get('default_workflow')
         self._resolution_presets: List[Tuple[str, str]] = self._parse_resolution_presets(
             self.config.get('resolutions')
         )
+        self._prompt_presets: List[PromptPreset] = self._load_prompt_presets(
+            self.config.get('prompt_presets_file')
+        )
+        self._prompt_preset_lookup: Dict[str, PromptPreset] = {}
+        self._prompt_preset_lookup_by_name: Dict[str, PromptPreset] = {}
+        self._prompt_preset_order: Dict[str, int] = {}
+        for idx, preset in enumerate(self._prompt_presets):
+            self._prompt_preset_lookup[preset.value] = preset
+            self._prompt_preset_lookup_by_name[preset.name.lower()] = preset
+            self._prompt_preset_order[preset.value] = idx
+
+        self._config_dir = self.config_path.parent
 
         # Get ComfyUI input directory from config
         self.input_dir = Path(self.config.get('comfyui', {}).get('input_dir', 'input'))
@@ -48,6 +81,127 @@ class WorkflowManager:
             presets.append((str(label), str(value)))
 
         return presets
+
+    def _load_prompt_presets(self, presets_path: Optional[str]) -> List[PromptPreset]:
+        """Load prompt presets from a JSON file."""
+
+        if not presets_path:
+            logger.info("Prompt presets file not configured; skipping presets")
+            return []
+
+        path = Path(presets_path)
+        if not path.is_absolute():
+            path = self.config_path.parent / path
+
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                raw_presets = json.load(f)
+        except FileNotFoundError:
+            logger.info("Prompt presets file %s not found; no presets loaded", path)
+            return []
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse prompt presets file %s: %s", path, exc)
+            return []
+
+        presets: List[PromptPreset] = []
+
+        def add_preset(name: Optional[str], tags: Optional[object], value: Optional[str] = None) -> None:
+            if not name or tags is None:
+                return
+
+            if isinstance(tags, list):
+                tags_str = ", ".join(str(tag).strip() for tag in tags if str(tag).strip())
+            else:
+                tags_str = str(tags).strip()
+
+            if not tags_str:
+                return
+
+            preset_value = value or self._slugify_value(name)
+            presets.append(PromptPreset(str(name), tags_str, preset_value))
+
+        if isinstance(raw_presets, dict):
+            for name, value in raw_presets.items():
+                if isinstance(value, dict):
+                    add_preset(value.get('name') or name, value.get('tags'), value.get('value'))
+                else:
+                    add_preset(name, value)
+        elif isinstance(raw_presets, list):
+            for idx, item in enumerate(raw_presets):
+                if isinstance(item, dict):
+                    add_preset(item.get('name') or item.get('title'), item.get('tags'), item.get('value'))
+                else:
+                    add_preset(f"Preset {idx + 1}", item)
+
+        if presets:
+            logger.info("Loaded %d prompt presets from %s", len(presets), path)
+        else:
+            logger.info("No valid prompt presets found in %s", path)
+
+        return presets
+
+    def _slugify_value(self, name: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+        return slug or uuid.uuid4().hex
+
+    def get_prompt_presets(self) -> List[PromptPreset]:
+        """Expose loaded prompt presets."""
+
+        return list(self._prompt_presets)
+
+    def search_prompt_presets(self, query: str = "", *, limit: int = 25) -> List[PromptPreset]:
+        """Return prompt presets filtered by query."""
+
+        normalized = (query or "").strip().lower()
+        if not normalized:
+            return self._prompt_presets[:limit]
+
+        def score(preset: PromptPreset) -> tuple[int, int]:
+            name_l = preset.name.lower()
+            tags_l = preset.tags.lower()
+            if name_l.startswith(normalized):
+                priority = 3
+            elif normalized in name_l:
+                priority = 2
+            elif normalized in tags_l:
+                priority = 1
+            else:
+                priority = 0
+            return (-priority, self._prompt_preset_order.get(preset.value, 0))
+
+        scored = [
+            (score(preset), preset)
+            for preset in self._prompt_presets
+            if normalized in preset.name.lower() or normalized in preset.tags.lower()
+        ]
+        if not scored:
+            return self._prompt_presets[:limit]
+
+        scored.sort(key=lambda item: item[0])
+        return [preset for _, preset in scored[:limit]]
+
+    def apply_prompt_preset(
+        self,
+        preset_value: Optional[str],
+        prompt: Optional[str],
+    ) -> tuple[str, Optional[str], Optional[str]]:
+        """Return prompt updated with preset tags, plus preset name and tags."""
+
+        if not preset_value:
+            return prompt or "", None, None
+
+        normalized_value = preset_value.strip().lower()
+        preset = (
+            self._prompt_preset_lookup.get(preset_value)
+            or self._prompt_preset_lookup.get(self._slugify_value(normalized_value))
+            or self._prompt_preset_lookup_by_name.get(normalized_value)
+        )
+        if not preset:
+            logger.warning("Prompt preset '%s' not found; using original prompt", preset_value)
+            return prompt or "", None, None
+
+        combined = preset.apply(prompt)
+        return combined, preset.name, preset.tags
 
     def get_resolution_presets(self) -> List[Tuple[str, str]]:
         """Return configured resolution presets as (label, value) tuples."""

--- a/src/core/generation_queue.py
+++ b/src/core/generation_queue.py
@@ -27,25 +27,29 @@ class GenerationQueue:
     """Manages queued generation requests."""
 
     def __init__(self) -> None:
-        self._queue: "asyncio.Queue[QueuedGeneration]" = asyncio.Queue()
+        self._queue: "asyncio.PriorityQueue[tuple[int, int, QueuedGeneration]]" = asyncio.PriorityQueue()
         self._worker: Optional[asyncio.Task[None]] = None
         self._current: Optional[QueuedGeneration] = None
+        self._counter: int = 0
 
     async def add_to_queue(
         self,
         generation_func: Callable[..., Awaitable[None]],
         context: "GenerationContext",
         *args,
+        priority: int = 0,
         **kwargs,
     ) -> None:
         """Add a new generation request to the queue."""
 
         job = QueuedGeneration(generation_func, args, kwargs, context)
-        await self._queue.put(job)
+        self._counter += 1
+        await self._queue.put((-priority, self._counter, job))
         logger.info(
-            "Queue: added request for user %s • size=%d",
+            "Queue: added request for user %s • size=%d • priority=%d",
             context.user_id,
             self._queue.qsize(),
+            priority,
         )
 
         if not self._worker or self._worker.done():
@@ -55,7 +59,7 @@ class GenerationQueue:
         """Process queued generation requests sequentially."""
 
         while True:
-            job = await self._queue.get()
+            _, _, job = await self._queue.get()
             self._current = job
 
             if job.context.cancel_event.is_set():
@@ -94,14 +98,15 @@ class GenerationQueue:
         """Remove a pending job from the queue if it hasn't started yet."""
 
         removed = False
-        pending: list[QueuedGeneration] = []
+        pending: list[tuple[int, int, QueuedGeneration]] = []
 
         while True:
             try:
-                job = self._queue.get_nowait()
+                entry = self._queue.get_nowait()
             except QueueEmpty:
                 break
 
+            _, _, job = entry
             if job.context is context:
                 removed = True
                 logger.info(
@@ -111,11 +116,11 @@ class GenerationQueue:
                 self._queue.task_done()
                 continue
 
-            pending.append(job)
+            pending.append(entry)
             self._queue.task_done()
 
-        for job in pending:
-            self._queue.put_nowait(job)
+        for entry in pending:
+            self._queue.put_nowait(entry)
 
         return removed
 


### PR DESCRIPTION
## Summary
- add explicit role tiers with per-tier limits, queue priority, and multi-slot allowances based on provided role IDs
- rework generation queue to a priority queue so higher tiers execute ahead of lower ones
- update limit enforcement and profile display to reflect tiered limits, unlimited access, and queue slot availability

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694611b5e8288331b062ed7da0d25f5c)