### PR TITLE
Add prompt preset selection for generation commands

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -32,6 +32,8 @@ resolutions:
   - label: "Portrait — 640x1536 (9:21)"
     value: "portrait - 640x1536 (9:21)"
 
+prompt_presets_file: data/prompt_presets.json
+
 workflows:
   ExpNEW:
     type: txt2img

--- a/data/prompt_presets.json
+++ b/data/prompt_presets.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Desuka Main",
+    "tags": "(masterpiece, best quality, very aesthetic, absurdres, highers, high definition, amazing quality, ultra detailed, very awa:1.2), (kakure_eria:0.7), (PumpkinSpiceLatte:0.5), (blvefo9:0.5), (1=2),"
+  },
+  {
+    "name": "Desuka Main 2",
+    "tags": ["(masterpiece, best quality, very aesthetic, absurdres, highers, high definition, amazing quality, ultra detailed, very awa:1.2), (kakure_eria:0.7), (PumpkinSpiceLatte:0.5), (blvefo9:0.5), (1=2), butterchalk,"]
+  }
+]

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -12,12 +12,22 @@ def rgen_command(bot):
         for label, value in bot.workflow_manager.get_resolution_presets()[:25]
     ]
 
+    async def _prompt_preset_autocomplete(
+            interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        presets = bot.workflow_manager.search_prompt_presets(current, limit=25)
+        return [
+            app_commands.Choice(name=preset.name, value=preset.value)
+            for preset in presets
+        ]
+
     @app_commands.command(
         name="rgen",
         description="Forge an image using text-to-image"
     )
     @app_commands.describe(
         prompt="Description of the image you want to create",
+        prompt_preset="Select a prompt preset (optional)",
         resolution="Select the output resolution (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
@@ -25,6 +35,7 @@ def rgen_command(bot):
     async def rgen(
             interaction: discord.Interaction,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             resolution: Optional[app_commands.Choice[str]] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
@@ -37,10 +48,12 @@ def rgen_command(bot):
             workflow,
             settings,
             resolution=selected_resolution,
+            prompt_preset=prompt_preset,
         )
 
     if resolution_choices:
         rgen = app_commands.choices(resolution=resolution_choices)(rgen)
+    rgen = app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(rgen)
 
     return rgen
 
@@ -55,6 +68,7 @@ def reforge_command(bot):
     @app_commands.describe(
         image="The image to reforge",
         prompt="Description of the changes you want to make",
+        prompt_preset="Select a prompt preset (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
     )
@@ -62,6 +76,7 @@ def reforge_command(bot):
             interaction: discord.Interaction,
             image: discord.Attachment,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
@@ -71,10 +86,11 @@ def reforge_command(bot):
             prompt,
             workflow,
             settings,
+            prompt_preset=prompt_preset,
             input_image=image,
         )
 
-    return reforge
+    return app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(reforge)
 
 
 def upscale_command(bot):
@@ -87,6 +103,7 @@ def upscale_command(bot):
     @app_commands.describe(
         image="The image to upscale",
         prompt="Description of the changes you want to make",
+        prompt_preset="Select a prompt preset (optional)",
         workflow="The workflow to use (optional)",
         settings="Additional settings (optional)"
     )
@@ -94,6 +111,7 @@ def upscale_command(bot):
             interaction: discord.Interaction,
             image: discord.Attachment,
             prompt: str,
+            prompt_preset: Optional[str] = None,
             workflow: Optional[str] = None,
             settings: Optional[str] = None
     ):
@@ -103,10 +121,11 @@ def upscale_command(bot):
             prompt,
             workflow,
             settings,
+            prompt_preset=prompt_preset,
             input_image=image,
         )
 
-    return upscale
+    return app_commands.autocomplete(prompt_preset=_prompt_preset_autocomplete)(upscale)
 
 
 def workflows_command(bot):

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -1520,11 +1520,7 @@ class ComfyUIBot(commands.Bot):
         if extra_fields:
             fields.extend(extra_fields)
         if context.prompt_preset_name:
-            preset_value = context.prompt_preset_name
-            if context.prompt_preset_tags:
-                tags_preview = self._truncate_field(context.prompt_preset_tags, 900)
-                preset_value = f"{context.prompt_preset_name}\n{tags_preview}"
-            fields.append(("🏷️ Preset", preset_value, False))
+            fields.append(("🏷️ Preset", context.prompt_preset_name, True))
         if context.resolution:
             fields.append(("🖼️ Resolution", context.resolution, True))
         fields.append(("🕒 Started", f"<t:{int(context.started_at)}:R>", True))
@@ -1540,11 +1536,6 @@ class ComfyUIBot(commands.Bot):
             usage=self._usage_text(context),
             fields=fields,
         )
-
-    def _truncate_field(self, value: str, limit: int = 900) -> str:
-        if len(value) <= limit:
-            return value
-        return value[: limit - 1] + "…"
 
     def _usage_text(self, context: GenerationContext) -> Optional[str]:
         if context.is_donor:

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -55,6 +55,8 @@ class GenerationContext:
     workflow_type: str
     is_donor: bool
     prompt: Optional[str] = None
+    prompt_preset_name: Optional[str] = None
+    prompt_preset_tags: Optional[str] = None
     settings: Optional[str] = None
     resolution: Optional[str] = None
     started_at: float = field(default_factory=time.time)
@@ -1119,7 +1121,9 @@ class ComfyUIBot(commands.Bot):
         workflow: Optional[str] = None,
         settings: Optional[str] = None,
         resolution: Optional[str] = None,
+        prompt_preset: Optional[str] = None,
         input_image: Optional[discord.Attachment] = None,
+        **_: Any,
     ) -> None:
         user_id = str(interaction.user.id)
         self._reset_counts_if_needed()
@@ -1158,6 +1162,8 @@ class ComfyUIBot(commands.Bot):
         is_supporter = tier.daily_limit is None
         is_donor = is_supporter or user_id in self.donor_users
 
+        final_prompt, preset_name, preset_tags = self.workflow_manager.apply_prompt_preset(prompt_preset, prompt)
+
         context = GenerationContext(
             user_id=user_id,
             user=interaction.user,
@@ -1165,12 +1171,14 @@ class ComfyUIBot(commands.Bot):
             is_donor=is_donor,
             tier=tier,
             daily_limit=tier.daily_limit,
-            prompt=prompt,
+            prompt=final_prompt,
+            prompt_preset_name=preset_name,
+            prompt_preset_tags=preset_tags,
             settings=settings,
             resolution=resolution,
         )
 
-        context.force_spoiler = self._prompt_contains_spoiler_tag(prompt)
+        context.force_spoiler = self._prompt_contains_spoiler_tag(final_prompt)
 
         try:
             if tier.daily_limit is not None:
@@ -1203,9 +1211,9 @@ class ComfyUIBot(commands.Bot):
             context.slot_counted = True
             try:
                 asyncio.create_task(
-                    self._publish_active_delta(
-                        user_id=int(user_id),
-                        delta=1,
+                self._publish_active_delta(
+                    user_id=int(user_id),
+                    delta=1,
                         tier_name=tier.name,
                         queue_priority=tier.queue_priority,
                         max_parallel=tier.max_parallel_generations,
@@ -1216,7 +1224,7 @@ class ComfyUIBot(commands.Bot):
             await self._process_generation(
                 interaction,
                 workflow_type,
-                prompt,
+                final_prompt,
                 workflow,
                 settings,
                 resolution,
@@ -1511,6 +1519,12 @@ class ComfyUIBot(commands.Bot):
         fields: List[ui_embeds.EmbedField] = [("🎯 Mode", context.workflow_type.upper(), True)]
         if extra_fields:
             fields.extend(extra_fields)
+        if context.prompt_preset_name:
+            preset_value = context.prompt_preset_name
+            if context.prompt_preset_tags:
+                tags_preview = self._truncate_field(context.prompt_preset_tags, 900)
+                preset_value = f"{context.prompt_preset_name}\n{tags_preview}"
+            fields.append(("🏷️ Preset", preset_value, False))
         if context.resolution:
             fields.append(("🖼️ Resolution", context.resolution, True))
         fields.append(("🕒 Started", f"<t:{int(context.started_at)}:R>", True))
@@ -1526,6 +1540,11 @@ class ComfyUIBot(commands.Bot):
             usage=self._usage_text(context),
             fields=fields,
         )
+
+    def _truncate_field(self, value: str, limit: int = 900) -> str:
+        if len(value) <= limit:
+            return value
+        return value[: limit - 1] + "…"
 
     def _usage_text(self, context: GenerationContext) -> Optional[str]:
         if context.is_donor:

--- a/src/comfy/workflow_manager.py
+++ b/src/comfy/workflow_manager.py
@@ -1,5 +1,7 @@
 import json
+import re
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -8,15 +10,46 @@ import yaml
 from logger import logger
 
 
+@dataclass(frozen=True)
+class PromptPreset:
+    name: str
+    tags: str
+    value: str
+
+    def apply(self, prompt: Optional[str]) -> str:
+        """Prepend the preset tags to the provided prompt."""
+
+        base_prompt = prompt.strip() if prompt else ""
+        prefix = self.tags.strip()
+
+        if not prefix:
+            return base_prompt
+
+        return f"{prefix} {base_prompt}".strip()
+
+
 class WorkflowManager:
     """Manages ComfyUI workflows and their configurations"""
     def __init__(self, config_path: str):
+        self.config_path = Path(config_path)
         self.config = self._load_config(config_path)
         self.workflows = self.config['workflows']
         self.default_workflow = self.config.get('default_workflow')
         self._resolution_presets: List[Tuple[str, str]] = self._parse_resolution_presets(
             self.config.get('resolutions')
         )
+        self._prompt_presets: List[PromptPreset] = self._load_prompt_presets(
+            self.config.get('prompt_presets_file')
+        )
+        self._prompt_preset_lookup: Dict[str, PromptPreset] = {}
+        self._prompt_preset_lookup_by_name: Dict[str, PromptPreset] = {}
+        self._prompt_preset_order: Dict[str, int] = {}
+        for idx, preset in enumerate(self._prompt_presets):
+            self._prompt_preset_lookup[preset.value] = preset
+            self._prompt_preset_lookup_by_name[preset.name.lower()] = preset
+            self._prompt_preset_order[preset.value] = idx
+
+        self._config_dir = self.config_path.parent
 
         # Get ComfyUI input directory from config
         self.input_dir = Path(self.config.get('comfyui', {}).get('input_dir', 'input'))
@@ -48,6 +81,127 @@ class WorkflowManager:
             presets.append((str(label), str(value)))
 
         return presets
+
+    def _load_prompt_presets(self, presets_path: Optional[str]) -> List[PromptPreset]:
+        """Load prompt presets from a JSON file."""
+
+        if not presets_path:
+            logger.info("Prompt presets file not configured; skipping presets")
+            return []
+
+        path = Path(presets_path)
+        if not path.is_absolute():
+            path = self.config_path.parent / path
+
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                raw_presets = json.load(f)
+        except FileNotFoundError:
+            logger.info("Prompt presets file %s not found; no presets loaded", path)
+            return []
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse prompt presets file %s: %s", path, exc)
+            return []
+
+        presets: List[PromptPreset] = []
+
+        def add_preset(name: Optional[str], tags: Optional[object], value: Optional[str] = None) -> None:
+            if not name or tags is None:
+                return
+
+            if isinstance(tags, list):
+                tags_str = ", ".join(str(tag).strip() for tag in tags if str(tag).strip())
+            else:
+                tags_str = str(tags).strip()
+
+            if not tags_str:
+                return
+
+            preset_value = value or self._slugify_value(name)
+            presets.append(PromptPreset(str(name), tags_str, preset_value))
+
+        if isinstance(raw_presets, dict):
+            for name, value in raw_presets.items():
+                if isinstance(value, dict):
+                    add_preset(value.get('name') or name, value.get('tags'), value.get('value'))
+                else:
+                    add_preset(name, value)
+        elif isinstance(raw_presets, list):
+            for idx, item in enumerate(raw_presets):
+                if isinstance(item, dict):
+                    add_preset(item.get('name') or item.get('title'), item.get('tags'), item.get('value'))
+                else:
+                    add_preset(f"Preset {idx + 1}", item)
+
+        if presets:
+            logger.info("Loaded %d prompt presets from %s", len(presets), path)
+        else:
+            logger.info("No valid prompt presets found in %s", path)
+
+        return presets
+
+    def _slugify_value(self, name: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+        return slug or uuid.uuid4().hex
+
+    def get_prompt_presets(self) -> List[PromptPreset]:
+        """Expose loaded prompt presets."""
+
+        return list(self._prompt_presets)
+
+    def search_prompt_presets(self, query: str = "", *, limit: int = 25) -> List[PromptPreset]:
+        """Return prompt presets filtered by query."""
+
+        normalized = (query or "").strip().lower()
+        if not normalized:
+            return self._prompt_presets[:limit]
+
+        def score(preset: PromptPreset) -> tuple[int, int]:
+            name_l = preset.name.lower()
+            tags_l = preset.tags.lower()
+            if name_l.startswith(normalized):
+                priority = 3
+            elif normalized in name_l:
+                priority = 2
+            elif normalized in tags_l:
+                priority = 1
+            else:
+                priority = 0
+            return (-priority, self._prompt_preset_order.get(preset.value, 0))
+
+        scored = [
+            (score(preset), preset)
+            for preset in self._prompt_presets
+            if normalized in preset.name.lower() or normalized in preset.tags.lower()
+        ]
+        if not scored:
+            return self._prompt_presets[:limit]
+
+        scored.sort(key=lambda item: item[0])
+        return [preset for _, preset in scored[:limit]]
+
+    def apply_prompt_preset(
+        self,
+        preset_value: Optional[str],
+        prompt: Optional[str],
+    ) -> tuple[str, Optional[str], Optional[str]]:
+        """Return prompt updated with preset tags, plus preset name and tags."""
+
+        if not preset_value:
+            return prompt or "", None, None
+
+        normalized_value = preset_value.strip().lower()
+        preset = (
+            self._prompt_preset_lookup.get(preset_value)
+            or self._prompt_preset_lookup.get(self._slugify_value(normalized_value))
+            or self._prompt_preset_lookup_by_name.get(normalized_value)
+        )
+        if not preset:
+            logger.warning("Prompt preset '%s' not found; using original prompt", preset_value)
+            return prompt or "", None, None
+
+        combined = preset.apply(prompt)
+        return combined, preset.name, preset.tags
 
     def get_resolution_presets(self) -> List[Tuple[str, str]]:
         """Return configured resolution presets as (label, value) tuples."""


### PR DESCRIPTION
## Summary
- load prompt presets from a configurable JSON file
- expose presets via autocomplete and apply their tags ahead of user prompts
- surface selected preset details (name and tags) in generation embeds and add a sample presets file
- make handle_generation resilient to extra arguments, refine preset matching, and refresh sample presets content

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a223c96083318b260a25e7a85c25)