### PR TITLE
Fix bot sync resets clearing cached counts

### DIFF
--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -781,10 +781,21 @@ class ComfyUIBot(commands.Bot):
             limit_raw = tier_info.get("limit", payload.get("limit"))
             limit = None if limit_raw in (None, -1) else int(limit_raw)
             incoming_last_reset = reset_at - 86400.0
+            local_last_reset = getattr(self, "last_reset_time", 0)
 
-            if getattr(self, "last_reset_time", 0) > incoming_last_reset + 2:
+            if local_last_reset > incoming_last_reset + 2:
                 logger.debug("SYNC skipped — local reset is newer")
                 return
+
+            remote_reset_newer = incoming_last_reset > local_last_reset + 2
+            if remote_reset_newer:
+                logger.info(
+                    "SYNC detected newer reset from bot %s — clearing cached counts (local=%s remote=%s)",
+                    src_bot,
+                    local_last_reset,
+                    incoming_last_reset,
+                )
+                self.user_generation_counts.clear()
 
             if limit is None:
                 logger.debug(

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -797,6 +797,8 @@ class ComfyUIBot(commands.Bot):
                 )
                 self.user_generation_counts.clear()
                 self.user_generation_stats.clear()
+                self.synced_active_slots.pop(user_id, None)
+                self._synced_active_expiry.pop(user_id, None)
 
             if limit is None:
                 logger.debug(

--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -796,6 +796,7 @@ class ComfyUIBot(commands.Bot):
                     incoming_last_reset,
                 )
                 self.user_generation_counts.clear()
+                self.user_generation_stats.clear()
 
             if limit is None:
                 logger.debug(


### PR DESCRIPTION
## Summary
- clear cached generation counts when a synced update shows a newer reset
- log reset reconciliation to prevent stale limits across bots

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694784c0081c83318df1febd931fd29f)