### PR TITLE
Add IMG2VID workflow wiring for prompt/seed/image

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -438,6 +438,14 @@ workflows:
                           inp[f"lora_{i:02d}"] = "None"
                           inp[f"strength_{i:02d}"] = 0.0
 
+  IMG2VID:
+    type: img2img
+    description: Workflow image-to-video based on attached input image.
+    workflow: ./workflows/IMG2VID.json
+    text_prompt_node_id: "233:240"
+    image_input_node_id: 291
+    seed_node_id: 210
+
 security:
   access_guild_id: 1305851922644992080
   supporter_role_id: 1361296590777745560

--- a/src/comfy/workflow_manager.py
+++ b/src/comfy/workflow_manager.py
@@ -482,9 +482,13 @@ class WorkflowManager:
             node_id = str(workflow_config['text_prompt_node_id'])
             if node_id in modified_workflow:
                 node = modified_workflow[node_id]
-                if 'inputs' in node and 'text' in node['inputs']:
-                    node['inputs']['text'] = prompt
-                    logger.debug(f"Updated prompt in node {node_id}: {prompt}")
+                if 'inputs' in node:
+                    if 'text' in node['inputs']:
+                        node['inputs']['text'] = prompt
+                        logger.debug(f"Updated prompt in node {node_id}: {prompt}")
+                    elif 'prompt' in node['inputs']:
+                        node['inputs']['prompt'] = prompt
+                        logger.debug(f"Updated prompt in node {node_id}: {prompt}")
 
         # Update image if provided and node is configured
         if image_data and 'image_input_node_id' in workflow_config:


### PR DESCRIPTION
### Motivation
- Enable the IMG2VID workflow to be driven from configuration the same way as IMG2IMG so users can control prompt, seed and input image when invoking the workflow. 

### Description
- Add `IMG2VID` entry to `configuration.yml` with `text_prompt_node_id: "233:240"`, `image_input_node_id: 291`, and `seed_node_id: 210` so the workflow maps to the correct nodes. 
- Update `WorkflowManager.update_workflow_nodes` in `src/comfy/workflow_manager.py` to inject the prompt into either `inputs.text` or `inputs.prompt`, supporting the `PromptGenerator` node used by `IMG2VID`. 

### Testing
- Compiled relevant modules with `python -m py_compile src/comfy/workflow_manager.py src/bot/imagesmith.py src/bot/commands.py` and it succeeded. 
- Ran a runtime verification script that calls `WorkflowManager.prepare_workflow('IMG2VID', ...)` to assert the prompt is set on node `233:240`, seed is applied on node `210` (and randomized when omitted), and an input file is written for node `291`; all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad028ab908328a500201899115537)