### PR TITLE
Send only video outputs in video workflows

### DIFF
--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -1607,6 +1607,7 @@ class ComfyUIBot(commands.Bot):
                 seed=context.seed,
                 controlnet_strength=controlnet_strength,
             )
+            video_only_updates = self._workflow_outputs_video(workflow_json)
 
             if context.cancel_event.is_set():
                 await self._handle_cancelled_generation(context)
@@ -1650,6 +1651,7 @@ class ComfyUIBot(commands.Bot):
                 prompt_id,
                 update,
                 cancel_event=context.cancel_event,
+                video_only=video_only_updates,
             )
 
             if context.cancel_event.is_set():
@@ -1688,6 +1690,19 @@ class ComfyUIBot(commands.Bot):
                 except discord.HTTPException:
                     pass
             self._finalize_generation_context(context, success=context.completed)
+
+    @staticmethod
+    def _workflow_outputs_video(workflow_json: dict) -> bool:
+        """Return True when workflow appears to include video output nodes."""
+        video_markers = ("video", "animate", "gif", "vhs_")
+        for node in workflow_json.values():
+            if not isinstance(node, dict):
+                continue
+            class_type = str(node.get("class_type", "")).lower()
+            if any(marker in class_type for marker in video_markers):
+                return True
+        return False
+
     def _create_generation_view(self, context: GenerationContext) -> GenerationView:
         async def on_cancel(interaction: discord.Interaction) -> None:
             await self._handle_cancel_request(context, interaction)

--- a/src/comfy/client.py
+++ b/src/comfy/client.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timedelta
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import aiohttp
 import discord
@@ -342,11 +342,36 @@ class ComfyUIClient:
         percentage = int(100 * (value / max_value))
         return f"[{bar}] {percentage}%"
 
+    @staticmethod
+    def _is_video_filename(filename: str) -> bool:
+        return filename.lower().endswith((".mp4", ".webm", ".mov", ".mkv", ".avi", ".gif"))
+
+    def _extract_output_media(self, node_output: dict) -> Tuple[List[dict], List[dict]]:
+        """Split node outputs into video and image items."""
+        video_items: List[dict] = []
+        image_items: List[dict] = []
+
+        for key in ("videos", "gifs"):
+            for media in node_output.get(key, []):
+                if isinstance(media, dict) and media.get("filename"):
+                    video_items.append(media)
+
+        for media in node_output.get("images", []):
+            if not isinstance(media, dict) or "filename" not in media:
+                continue
+            if self._is_video_filename(media["filename"]):
+                video_items.append(media)
+            else:
+                image_items.append(media)
+
+        return video_items, image_items
+
     async def listen_for_updates(
         self,
         prompt_id: str,
         message_callback,
         cancel_event: Optional[asyncio.Event] = None,
+        video_only: bool = False,
     ):
         """Listen for updates about a specific generation."""
 
@@ -360,6 +385,8 @@ class ComfyUIClient:
 
         async def emit(status: str, image_file: Optional[discord.File] = None) -> None:
             await message_callback(status, image_file)
+
+        sent_video = False
 
         try:
             while True:
@@ -437,10 +464,33 @@ class ComfyUIClient:
                     if not isinstance(node_output, dict):
                         continue
 
-                    for image_data in node_output.get('images', []):
-                        if not isinstance(image_data, dict) or 'filename' not in image_data:
+                    video_outputs, image_outputs = self._extract_output_media(node_output)
+
+                    for video_data in video_outputs:
+                        video_url = self._get_image_url(instance, video_data)
+                        if not video_url:
                             continue
 
+                        async with session.get(video_url) as response:
+                            if response.status != 200:
+                                continue
+
+                            video_bytes = await response.read()
+                            video_file = discord.File(
+                                io.BytesIO(video_bytes),
+                                filename=video_data.get('filename', 'output.mp4'),
+                            )
+                            elapsed_time = time.time() - start_time
+                            await emit(
+                                f"🎬 New video generated!\n⏱ Time elapsed: {elapsed_time:.2f} seconds",
+                                video_file,
+                            )
+                            sent_video = True
+
+                    if video_only and sent_video:
+                        continue
+
+                    for image_data in image_outputs:
                         image_url = self._get_image_url(instance, image_data)
                         if not image_url:
                             continue


### PR DESCRIPTION
### Motivation
- Some workflows produce video outputs but also include image artifacts; the intent is to prefer sending videos and suppress image attachments for video-focused workflows.

### Description
- Detect video-oriented workflows by inspecting prepared workflow node `class_type` markers and expose a `video_only` flag via `listen_for_updates` by adding `ComfyUIBot._workflow_outputs_video` and passing `video_only` when starting the listener (`src/bot/imagesmith.py`).
- Add media extraction and video detection in the Comfy client by introducing `_is_video_filename` and `_extract_output_media`, which gather `videos`, `gifs` and any `images` whose filenames have video extensions (`src/comfy/client.py`).
- Update `listen_for_updates` to send video attachments with a `🎬 New video generated!` message, set a `sent_video` flag, and when `video_only` is true suppress subsequent image attachments (images still sent for non-video workflows) (`src/comfy/client.py`).
- Add typing import adjustments and keep existing image handling as a fallback; minimal behavioral change for non-video workflows (`src/comfy/client.py`, `src/bot/imagesmith.py`).

### Testing
- Ran `python -m compileall src` to validate the module syntax and byte-compile changes, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad80793f48328a6f2ae9041207fd5)